### PR TITLE
bind: Add IDN support by default

### DIFF
--- a/Formula/bind.rb
+++ b/Formula/bind.rb
@@ -57,7 +57,8 @@ class Bind < Formula
                           "--with-libjson=#{Formula["json-c"].opt_prefix}",
                           "--with-python-install-dir=#{vendor_site_packages}",
                           "--with-python=#{Formula["python@3.9"].opt_bin}/python3",
-                          "--without-lmdb"
+                          "--without-lmdb",
+                          "--with-libidn2=#{Formula["libidn2"].opt_prefix}"
 
     system "make"
     system "make", "install"

--- a/Formula/bind.rb
+++ b/Formula/bind.rb
@@ -203,5 +203,6 @@ class Bind < Formula
   test do
     system bin/"dig", "-v"
     system bin/"dig", "brew.sh"
+    system bin/"dig", "ü.cl"
   end
 end


### PR DESCRIPTION
Adding IDN support for BIND (and dig)

- [x] Have you followed the [guidelines for contributing](https://github.com/Homebrew/homebrew-core/blob/HEAD/CONTRIBUTING.md)?
- [x] Have you checked that there aren't other open [pull requests](https://github.com/Homebrew/homebrew-core/pulls) for the same formula update/change?
- [x] Have you built your formula locally with `brew install --build-from-source <formula>`, where `<formula>` is the name of the formula you're submitting?
- [x] Is your test running fine `brew test <formula>`, where `<formula>` is the name of the formula you're submitting?
- [ ] Does your build pass `brew audit --strict <formula>` (after doing `brew install <formula>`)?

-----
